### PR TITLE
fixed arg name in STAR reference command

### DIFF
--- a/src/slideseq/scripts/build_reference.sh
+++ b/src/slideseq/scripts/build_reference.sh
@@ -72,7 +72,7 @@ fi
 
 STAR --runMode genomeGenerate \
   --genomeDir ${OUTPUT_DIR}/STAR \
-  --outFilenamePrefix ${OUTPUT_DIR}/ \
+  --outFileNamePrefix ${OUTPUT_DIR}/ \
   --genomeFastaFiles ${OUTPUT_FASTA} \
   --sjdbGTFfile ${OUTPUT_GTF} \
   --sjdbOverhang 97 \


### PR DESCRIPTION
Guess I never used that script until now. `--outFilenamePrefix` -> `--outFileNamePrefix`