### PR TITLE
fixed circular import

### DIFF
--- a/src/slideseq/scripts/demultiplex.sh
+++ b/src/slideseq/scripts/demultiplex.sh
@@ -2,7 +2,7 @@
 #$ -N demux
 #$ -l os=RedHat7
 #$ -l h_vmem=16G
-#$ -l h_rt=4:0:0
+#$ -l h_rt=12:0:0
 #$ -pe smp 8
 #$ -binding linear:8
 #$ -terse

--- a/src/slideseq/util/__init__.py
+++ b/src/slideseq/util/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 import os
 import sys
@@ -6,8 +8,8 @@ from pathlib import Path
 from subprocess import PIPE, Popen, run
 from typing import Any, Union
 
+import slideseq.library as lib
 import slideseq.util.constants as constants
-from slideseq.library import Library
 
 log = logging.getLogger(__name__)
 
@@ -144,7 +146,7 @@ def get_lanes(run_info_file: Path) -> range:
     return range(1, lane_count + 1)
 
 
-def run_command(cmd: list[Any], name: str, library: Library, lane: int = None):
+def run_command(cmd: list[Any], name: str, library: lib.Library, lane: int = None):
     if lane is None:
         log.info(f"{name} for {library}")
     else:
@@ -165,7 +167,7 @@ def run_command(cmd: list[Any], name: str, library: Library, lane: int = None):
 def start_popen(
     cmd: list[Any],
     name: str,
-    library: Library,
+    library: lib.Library,
     lane: int = None,
     input_proc: Popen = None,
 ):


### PR DESCRIPTION
Haven't had one of those in a bit. Was using `library.Library` for a type annotation but it wanted to import that module.

Also upped demux h_rt because it was pretty short (only 4 hours) and a job timed out.