### PR TITLE
added tmp_dir to dropseq commands

### DIFF
--- a/src/slideseq/pipeline/alignment.py
+++ b/src/slideseq/pipeline/alignment.py
@@ -66,7 +66,12 @@ def main(
 
     procs = []
 
-    cmd = dropseq_cmd("TagBamWithReadSequenceExtended", library.raw_ubam, "/dev/stdout")
+    cmd = dropseq_cmd(
+        "TagBamWithReadSequenceExtended",
+        library.raw_ubam,
+        "/dev/stdout",
+        manifest.tmp_dir,
+    )
     cmd.extend(
         [
             f"SUMMARY={library.cellular_tagged_summary}",
@@ -89,7 +94,9 @@ def main(
     )
 
     # Tag bam with read sequence extended molecular
-    cmd = dropseq_cmd("TagBamWithReadSequenceExtended", "/dev/stdin", "/dev/stdout")
+    cmd = dropseq_cmd(
+        "TagBamWithReadSequenceExtended", "/dev/stdin", "/dev/stdout", manifest.tmp_dir
+    )
     cmd.extend(
         [
             f"SUMMARY={library.molecular_tagged_summary}",
@@ -112,13 +119,15 @@ def main(
     )
 
     # Filter low-quality reads
-    cmd = dropseq_cmd("FilterBam", "/dev/stdin", "/dev/stdout")
+    cmd = dropseq_cmd("FilterBam", "/dev/stdin", "/dev/stdout", manifest.tmp_dir)
     cmd.extend(["PASSING_READ_THRESHOLD=0.1", "TAG_REJECT=XQ"])
 
     procs.append(start_popen(cmd, "FilterBam", library, lane, procs[-1]))
 
     # Trim reads with starting sequence
-    cmd = dropseq_cmd("TrimStartingSequence", "/dev/stdin", "/dev/stdout")
+    cmd = dropseq_cmd(
+        "TrimStartingSequence", "/dev/stdin", "/dev/stdout", manifest.tmp_dir
+    )
     cmd.extend(
         [
             f"OUTPUT_SUMMARY={library.trimming_summary}",
@@ -131,7 +140,9 @@ def main(
     procs.append(start_popen(cmd, "TrimStartingSequence", library, lane, procs[-1]))
 
     # Adapter-aware poly A trimming
-    cmd = dropseq_cmd("PolyATrimmer", "/dev/stdin", library.polya_filtered_ubam)
+    cmd = dropseq_cmd(
+        "PolyATrimmer", "/dev/stdin", library.polya_filtered_ubam, manifest.tmp_dir
+    )
     cmd.extend(
         [
             f"OUTPUT_SUMMARY={library.polya_filtering_summary}",
@@ -236,7 +247,9 @@ def main(
     procs.append(start_popen(cmd, "MergeBamAlignment", library, lane, procs[-1]))
 
     # Tag read with interval
-    cmd = dropseq_cmd("TagReadWithInterval", "/dev/stdin", "/dev/stdout")
+    cmd = dropseq_cmd(
+        "TagReadWithInterval", "/dev/stdin", "/dev/stdout", manifest.tmp_dir
+    )
     cmd.extend([f"INTERVALS={library.reference.intervals}", "TAG=XG"])
 
     procs.append(start_popen(cmd, "TagReadWithInterval", library, lane, procs[-1]))
@@ -246,6 +259,7 @@ def main(
         "TagReadWithGeneFunction",
         "/dev/stdin",
         library.processed_bam,
+        manifest.tmp_dir,
         compression=5,
     )
     cmd.extend(

--- a/src/slideseq/pipeline/downsampling.py
+++ b/src/slideseq/pipeline/downsampling.py
@@ -30,7 +30,7 @@ def downsample_dge(
     run_command(cmd, "DownsampleSam", library)
 
     # output to /dev/null because we don't want to keep the DGE matrix
-    cmd = dropseq_cmd("DigitalExpression", downsampled_bam, "/dev/null")
+    cmd = dropseq_cmd("DigitalExpression", downsampled_bam, "/dev/null", tmp_dir)
     cmd.extend(
         [
             "CELL_BARCODE_TAG=XC",

--- a/src/slideseq/pipeline/processing.py
+++ b/src/slideseq/pipeline/processing.py
@@ -46,27 +46,27 @@ def calc_alignment_metrics(
 ):
     # Bam tag histogram (cells)
     cmd = dropseq_cmd(
-        "BamTagHistogram", input_base.bam, input_base.reads_per_cell(cell_tag)
+        "BamTagHistogram", input_base.bam, input_base.reads_per_cell(cell_tag), tmp_dir
     )
     cmd.extend(
         [
             f"TAG={cell_tag}",
             "FILTER_PCR_DUPLICATES=false",
             f"READ_MQ={library.base_quality}",
-            f"TMP_DIR={tmp_dir}",
         ]
     )
 
     run_command(cmd, "BamTagHistogram (cells)", library)
 
     # Bam tag histogram (UMIs)
-    cmd = dropseq_cmd("BamTagHistogram", input_base.bam, input_base.reads_per_umi)
+    cmd = dropseq_cmd(
+        "BamTagHistogram", input_base.bam, input_base.reads_per_umi, tmp_dir
+    )
     cmd.extend(
         [
             "TAG=XM",
             "FILTER_PCR_DUPLICATES=false",
             f"READ_MQ={library.base_quality}",
-            f"TMP_DIR={tmp_dir}",
         ]
     )
 
@@ -93,21 +93,30 @@ def calc_alignment_metrics(
 
     # Base distribution at read position for raw cellular barcode
     cmd = dropseq_cmd(
-        "BaseDistributionAtReadPosition", input_base.bam, input_base.xc_distribution
+        "BaseDistributionAtReadPosition",
+        input_base.bam,
+        input_base.xc_distribution,
+        tmp_dir,
     )
     cmd.extend(["TAG=XC"])
     run_command(cmd, "BaseDistributionAtReadPosition (Cellular)", library)
 
     # Base distribution at read position for molecular barcode
     cmd = dropseq_cmd(
-        "BaseDistributionAtReadPosition", input_base.bam, input_base.xm_distribution
+        "BaseDistributionAtReadPosition",
+        input_base.bam,
+        input_base.xm_distribution,
+        tmp_dir,
     )
     cmd.extend(["TAG=XM"])
     run_command(cmd, "BaseDistributionAtReadPosition (Molecular)", library)
 
     # Gather read quality metrics
     cmd = dropseq_cmd(
-        "GatherReadQualityMetrics", input_base.bam, input_base.read_quality_metrics
+        "GatherReadQualityMetrics",
+        input_base.bam,
+        input_base.read_quality_metrics,
+        tmp_dir,
     )
     run_command(cmd, "GatherReadQualityMetrics", library)
 
@@ -116,6 +125,7 @@ def calc_alignment_metrics(
             "SingleCellRnaSeqMetricsCollector",
             input_base.bam,
             input_base.frac_intronic_exonic_per_cell,
+            tmp_dir,
             compression=6,
         )
         cmd.extend(
@@ -134,6 +144,7 @@ def calc_alignment_metrics(
         "SelectCellsByNumTranscripts",
         input_base.bam,
         input_base.selected_cells,
+        tmp_dir,
         compression=6,
     )
     cmd.extend(
@@ -154,6 +165,7 @@ def calc_alignment_metrics(
         "DigitalExpression",
         input_base.bam,
         input_base.digital_expression,
+        tmp_dir,
         compression=6,
     )
     cmd.extend(

--- a/src/slideseq/util/__init__.py
+++ b/src/slideseq/util/__init__.py
@@ -62,6 +62,7 @@ def dropseq_cmd(
     command: str,
     input_file: Union[Path, str],
     output_file: Union[Path, str],
+    tmp_dir: Path,
     mem: str = "8g",
     compression: int = 0,
 ):
@@ -70,6 +71,7 @@ def dropseq_cmd(
     :param command: name of the dropseq tool being invoked
     :param input_file: path to the input file
     :param output_file: path to the output file
+    :param tmp_dir: Location of the tmp directory to use
     :param mem: memory for the heap. default is to share with other jobs
     :param compression: compression level for output. Use 0 for speed, 5 for storage
     """
@@ -80,6 +82,7 @@ def dropseq_cmd(
         mem,
         f"I={input_file}",
         f"O={output_file}",
+        f"TMP_DIR={tmp_dir}",
         "VALIDATION_STRINGENCY=SILENT",
         f"COMPRESSION_LEVEL={compression}",
         "VERBOSITY=WARNING",


### PR DESCRIPTION
I thought I remembered this failing somewhere, but I just checked all the `--stdhelp` strings (which are different from normal `--help` strings) and all the tools claim to support this.

Was getting some tmp_dir-related errors so I added this to hopefully solve that.

Currently testing this on a run just to make none of the commands complain.