### PR TITLE
fix mtx output, copy bead data

### DIFF
--- a/src/slideseq/library.py
+++ b/src/slideseq/library.py
@@ -104,11 +104,11 @@ class Base:
 
     @property
     def barcodes(self) -> Path:
-        return self.path.with_suffix(".digital_expression_barcodes.mtx.gz")
+        return self.path.with_suffix(".digital_expression_barcodes.tsv.gz")
 
     @property
     def genes(self) -> Path:
-        return self.path.with_suffix(".digital_expression_features.mtx.gz")
+        return self.path.with_suffix(".digital_expression_features.tsv.gz")
 
     @property
     def frac_intronic_exonic(self) -> Path:

--- a/src/slideseq/pipeline/processing.py
+++ b/src/slideseq/pipeline/processing.py
@@ -3,6 +3,7 @@
 import gzip
 import logging
 import os
+import shutil
 from pathlib import Path
 
 import click
@@ -251,6 +252,8 @@ def main(
 
     if library.run_barcodematching:
         library.barcode_matching_dir.mkdir(exist_ok=True, parents=True)
+        shutil.copy(library.bead_barcodes, library.barcode_matching_dir)
+        shutil.copy(library.bead_locations, library.barcode_matching_dir)
 
         barcode_mapping, bead_xy, bead_graph = match_barcodes(
             library.merged.selected_cells, library.bead_barcodes, library.bead_locations

--- a/src/slideseq/pipeline/write_matrix.py
+++ b/src/slideseq/pipeline/write_matrix.py
@@ -37,12 +37,12 @@ def write_sparse_matrix(library: Library):
         cols = next(rdr)[1:]
         rows = [r[0] for r in rdr]
 
-    with library.matched.barcodes.open("w") as out:
+    with gzip.open(library.matched.barcodes, "wt") as out:
         for bc in cols:
             print(bc, file=out)
 
     # write features (genes) file
-    with library.matched.genes.open("w") as out:
+    with gzip.open(library.matched.genes, "wt") as out:
         for gene in rows:
             print(f"{gene_dict.get(gene, gene)}\t{gene}", file=out)
 


### PR DESCRIPTION
- fixed bug with mtx file: had wrong names for gene and barcode file, and wasn't gzipping them
- copy beadbarcodes and beadlocations to output folder to simplify data access