### PR TITLE
Keep full aligned BAMs

### DIFF
--- a/src/slideseq/pipeline/processing.py
+++ b/src/slideseq/pipeline/processing.py
@@ -312,10 +312,6 @@ def main(
         log.debug(f"Removing {bam_file}")
         os.remove(bam_file)
 
-    log.debug(f"Removing {library.merged.bam}")
-    os.remove(library.merged.bam)
-    os.remove(library.merged.bam.with_suffix(".bai"))
-
     if matched_barcodes_file.exists():
         log.debug(f"Removing {matched_barcodes_file}")
         os.remove(matched_barcodes_file)


### PR DESCRIPTION
Keep these files for posterity because some experiments won't produce a matched bam. With the automated rsync this shouldn't be a big waste of space.