### PR TITLE
added code to process dual-indexed data

### DIFF
--- a/src/slideseq/util/__init__.py
+++ b/src/slideseq/util/__init__.py
@@ -109,9 +109,15 @@ def get_read_structure(run_info_file: Path) -> str:
     read_elems = run_info.findall("./Run/Reads/Read[@NumCycles][@Number]")
     read_elems.sort(key=lambda el: int(el.get("Number")))
 
-    assert len(read_elems) == 3, f"Expected three reads, got {len(read_elems)}"
+    if len(read_elems) == 4:
+        # two index reads. We will just ignore the second index
+        log.warning(
+            "This sequencing run has two index reads, we are ignoring the second one"
+        )
+        return "{}T{}B{}S{}T".format(*(el.get("NumCycles") for el in read_elems))
+    elif len(read_elems) != 3:
+        raise ValueError(f"Expected three reads, got {len(read_elems)}")
 
-    # I guess Picard wants this string format for some reason
     return "{}T{}B{}T".format(*(el.get("NumCycles") for el in read_elems))
 
 


### PR DESCRIPTION
Sometime we get sequencing data with two indexes where we only expect one. The simple solution is to ignore the second index (of course, if that index is necessary this won't work). This PR implements that change, outputting a warning message when it happens because it's not the standard protocol and we should be aware when it happens.