### PR TITLE
Combine replicates

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Again, you should do this from an interactive session, as downloading the worksh
 use UGER  # for submitting jobs to the cluster
 use Google-Cloud-SDK  # for accessing the Google worksheet
 conda activate slideseq
-submit_flowcell FLOWCELL [FLOWCELL...]
+submit_slideseq RUN [RUN...]
 ```
 
 This is will submit a set of jobs to process the flowcell(s). You will get emails when the jobs start and end.

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setuptools.setup(
     extras_require={"dev": ["black", "isort", "flake8", "pre-commit"]},
     entry_points={
         "console_scripts": [
-            "submit_flowcell = slideseq.pipeline.submit_slideseq:main",
+            "submit_slideseq = slideseq.pipeline.submit_slideseq:main",
             "align_library = slideseq.pipeline.alignment:main",
             "process_library = slideseq.pipeline.processing:main",
             "build_ref = slideseq.pipeline.reference:main",

--- a/src/slideseq/config.py
+++ b/src/slideseq/config.py
@@ -20,7 +20,7 @@ class Config:
     library_dir: Path
     gsheet_id: str
     worksheet: str
-    gs_path: str
+    gs_path: Path
 
     @staticmethod
     def from_file(input_file: Path):
@@ -37,7 +37,7 @@ class Config:
             library_dir=Path(data["library_dir"]),
             gsheet_id=data["gsheet_id"],
             worksheet=data["worksheet"],
-            gs_path=data["gs_path"],
+            gs_path=Path(data["gs_path"]),
         )
 
     def dropseq_cmd(

--- a/src/slideseq/config.yaml
+++ b/src/slideseq/config.yaml
@@ -5,4 +5,4 @@ workflow_dir: /broad/macosko/data/workflows/flowcell
 library_dir: /broad/macosko/data/libraries
 gsheet_id: 1kwnKrkbl80LyE9lND0UZZJXipL4yfBbGjkTe6hcwJic
 worksheet: 'Experiment Log'
-gs_path: gs://macosko_data/libraries
+gs_path: macosko_data/libraries

--- a/src/slideseq/library.py
+++ b/src/slideseq/library.py
@@ -194,9 +194,14 @@ class Library:
         return self.row.gen_downsampling
 
     @property
+    def date_name(self) -> str:
+        """Unique library name and date"""
+        return f"{self.row.date}_{self.name}"
+
+    @property
     def dir(self) -> Path:
         """Base directory for the library data"""
-        return self.library_dir / f"{self.row.date}_{self.name}"
+        return self.library_dir / self.date_name
 
     @property
     def barcode_matching_dir(self) -> Path:

--- a/src/slideseq/library.py
+++ b/src/slideseq/library.py
@@ -131,7 +131,7 @@ class Library:
     # generated during processing
     name: str
     row: pd.Series
-    lanes: list[int]
+    flowcell_lanes: list[tuple[str, int]]
     reference: Reference
     library_dir: Path
 
@@ -236,10 +236,10 @@ class Library:
 
     def per_lane(self, *args, suffix) -> list[Path]:
         return [
-            ((self.dir / f"L{lane:03d}").joinpath(*args) / self.base).with_suffix(
-                suffix
-            )
-            for lane in self.lanes
+            (
+                (self.dir / flowcell / f"L{lane:03d}").joinpath(*args) / self.base
+            ).with_suffix(suffix)
+            for flowcell, lane in self.flowcell_lanes
         ]
 
     @property
@@ -268,11 +268,12 @@ class Library:
 
 @dataclass
 class LibraryLane(Library):
+    flowcell: str
     lane: int
 
     @property
     def lane_dir(self) -> Path:
-        return self.dir / f"L{self.lane:03d}"
+        return self.dir / self.flowcell / f"L{self.lane:03d}"
 
     @property
     def raw_ubam(self) -> Path:

--- a/src/slideseq/library.py
+++ b/src/slideseq/library.py
@@ -277,14 +277,23 @@ class Sample(Library):
 
     flowcell: str
     lane: int
+    barcodes: list[str]
 
     @property
     def lane_dir(self) -> Path:
         return self.dir / self.flowcell / f"L{self.lane:03d}"
 
     @property
+    def barcode_ubams(self) -> list[Path]:
+        """One unmapped BAM per barcode, merged into raw_ubam"""
+        return [
+            (self.lane_dir / self.base).with_suffix(f".{barcode}.unmapped.bam")
+            for barcode in self.barcodes
+        ]
+
+    @property
     def raw_ubam(self) -> Path:
-        """Raw unmapped BAM from demux. Keep this one for posterity"""
+        """Raw unmapped BAM. Keep this one for posterity"""
         return (self.lane_dir / self.base).with_suffix(".unmapped.bam")
 
     @property

--- a/src/slideseq/library.py
+++ b/src/slideseq/library.py
@@ -130,8 +130,8 @@ class Library:
     # a dataclass to represent a single library that defines all the files
     # generated during processing
     name: str
-    row: pd.Series
-    flowcell_lanes: list[tuple[str, int]]
+    data: pd.Series
+    samples: dict[tuple[str, int], list[str]]
     reference: Reference
     library_dir: Path
 
@@ -150,7 +150,7 @@ class Library:
         #   - 2 * (iter(re),) makes a second reference (not copy) to the iterator
         #   - zip(*(2iter)) zips together pairs of elements
         # then, add up the lengths to get ranges
-        for j, c in zip(*(2 * (iter(re.split("([CXM])", self.row.bead_structure)),))):
+        for j, c in zip(*(2 * (iter(re.split("([CXM])", self.data.bead_structure)),))):
             j = int(j)
             intervals.append((c, i, i + j - 1))
             i += j
@@ -159,23 +159,23 @@ class Library:
 
     @property
     def base_quality(self) -> int:
-        return self.row.base_quality
+        return self.data.base_quality
 
     @property
     def start_sequence(self) -> str:
-        return self.row.start_sequence
+        return self.data.start_sequence
 
     @property
     def min_transcripts_per_cell(self) -> int:
-        return self.row.min_transcripts_per_cell
+        return self.data.min_transcripts_per_cell
 
     @property
     def locus_function_list(self) -> str:
-        return self.row.locus_function_list
+        return self.data.locus_function_list
 
     @property
     def puckcaller_path(self) -> Path:
-        return Path(self.row.puckcaller_path)
+        return Path(self.data.puckcaller_path)
 
     @property
     def bead_barcodes(self) -> Path:
@@ -187,16 +187,16 @@ class Library:
 
     @property
     def run_barcodematching(self) -> bool:
-        return self.row.run_barcodematching
+        return self.data.run_barcodematching
 
     @property
     def gen_downsampling(self) -> bool:
-        return self.row.gen_downsampling
+        return self.data.gen_downsampling
 
     @property
     def date_name(self) -> str:
         """Unique library name and date"""
-        return f"{self.row.date}_{self.name}"
+        return f"{self.data.date}_{self.name}"
 
     @property
     def dir(self) -> Path:
@@ -239,40 +239,42 @@ class Library:
             min_transcripts_per_cell=self.min_transcripts_per_cell,
         )
 
-    def per_lane(self, *args, suffix) -> list[Path]:
+    def per_sample(self, *args, suffix) -> list[Path]:
         return [
             (
                 (self.dir / flowcell / f"L{lane:03d}").joinpath(*args) / self.base
             ).with_suffix(suffix)
-            for flowcell, lane in self.flowcell_lanes
+            for flowcell, lane in self.samples
         ]
 
     @property
     def polya_filtering_summaries(self) -> list[Path]:
         """polyA filtering summary"""
-        return self.per_lane("alignment", suffix=".polyA_filtering.summary.txt")
+        return self.per_sample("alignment", suffix=".polyA_filtering.summary.txt")
 
     @property
     def star_logs(self) -> list[Path]:
         """Log files from STAR alignment"""
-        return self.per_lane("alignment", suffix=".star.Log.final.out")
+        return self.per_sample("alignment", suffix=".star.Log.final.out")
 
     @property
     def alignment_pickles(self) -> list[Path]:
         """Pickle files containing statistics about the alignment"""
-        return self.per_lane("alignment", suffix=".alignment_statistics.pickle")
+        return self.per_sample("alignment", suffix=".alignment_statistics.pickle")
 
     @property
     def processed_bams(self) -> list[Path]:
         """Final aligned+unmapped output BAMs"""
-        return self.per_lane(suffix=".final.bam")
+        return self.per_sample(suffix=".final.bam")
 
     def __str__(self):
         return self.name
 
 
 @dataclass
-class LibraryLane(Library):
+class Sample(Library):
+    """Represent a single entry in a samplesheet, which may be part of a larger library"""
+
     flowcell: str
     lane: int
 

--- a/src/slideseq/metadata.py
+++ b/src/slideseq/metadata.py
@@ -104,7 +104,10 @@ class Manifest:
 def validate_run_df(run_name: str, run_df: pd.DataFrame) -> bool:
     warning_logs = []
 
-    if len(set(run_df.library)) != len(run_df.library):
+    library_tuples = list(
+        run_df[["library", *constants.VARIABLE_LIBRARY_COLS]].itertuples()
+    )
+    if len(set(library_tuples)) != len(library_tuples):
         warning_logs.append(
             f"{run_name} does not have unique library names;"
             " please fill out naming metadata correctly or add suffixes."
@@ -122,7 +125,7 @@ def validate_run_df(run_name: str, run_df: pd.DataFrame) -> bool:
             " and blue cols); please fill out before running."
         )
 
-    bcl_path_set = set(run_df.bclpath)
+    bcl_path_set = set(map(Path, run_df.bclpath))
     for bcl_path in bcl_path_set:
         if not bcl_path.is_dir():
             warning_logs.append(
@@ -164,7 +167,7 @@ def split_sample_lanes(run_df: pd.DataFrame, run_info_list: list[RunInfo]):
     run_info_d = {run_info.run_dir: run_info for run_info in run_info_list}
 
     for _, row in run_df.iterrows():
-        flowcell_dir = Path(run_df.bclpath)
+        flowcell_dir = Path(row.bclpath)
 
         # write the correct flowcell barcode as an entry in the row,
         # possibly replacing whatever string was there

--- a/src/slideseq/metadata.py
+++ b/src/slideseq/metadata.py
@@ -13,6 +13,9 @@ from slideseq.library import Library, LibraryLane, Reference
 log = logging.getLogger(__name__)
 
 
+RunInfo = dict[Path, (str, range, str)]
+
+
 @dataclass
 class Manifest:
     run_name: str
@@ -146,12 +149,13 @@ def validate_run_df(run_name: str, run_df: pd.DataFrame) -> bool:
         return True
 
 
-def split_sample_lanes(flowcell_df: pd.DataFrame, lanes: range):
+def split_sample_lanes(run_df: pd.DataFrame, run_info: RunInfo):
     new_rows = []
 
-    for _, row in flowcell_df.iterrows():
-        if row.lane == "{LANE}":
-            row_lanes = lanes
+    for _, row in run_df.iterrows():
+        flowcell_dir = Path(run_df.bclpath)
+        if row.lane == constants.ALL_LANES:
+            row_lanes = run_info[flowcell_dir][1]
         else:
             row_lanes = str(row.lane).split(",")
 

--- a/src/slideseq/metadata.py
+++ b/src/slideseq/metadata.py
@@ -225,12 +225,13 @@ def validate_library_df(library_name: str, library_df: pd.DataFrame):
         if col in constants.VARIABLE_LIBRARY_COLS:
             continue
 
-        if len(set(library_df[col])) != 1:
+        col_vals = set(library_df[col])
+        if len(col_vals) != 1:
             raise ValueError(
                 f"Library {library_name} has multiple values in column {col}"
             )
 
-        library_data[col] = library_df[col][0]
+        library_data[col] = col_vals.pop()
 
     samples = {
         (flowcell, lane): list(sample_df[constants.VARIABLE_LIBRARY_COLS[-1]])

--- a/src/slideseq/pipeline/alignment.py
+++ b/src/slideseq/pipeline/alignment.py
@@ -16,7 +16,7 @@ log = logging.getLogger(__name__)
 
 
 @click.command(name="align_library", no_args_is_help=True)
-@click.option("--flowcell", type=int, required=True, help="Flowcell being aligned")
+@click.option("--flowcell", required=True, help="Flowcell being aligned")
 @click.option(
     "--lane", type=int, required=True, help="Lane of the flowcell being aligned"
 )

--- a/src/slideseq/pipeline/alignment.py
+++ b/src/slideseq/pipeline/alignment.py
@@ -50,32 +50,56 @@ def main(
     manifest = Manifest.from_file(Path(manifest_file))
 
     # task array is 1-indexed
-    library = manifest.get_sample(library_index - 1, flowcell, lane)
-    if library is None:
+    sample = manifest.get_sample(library_index - 1, flowcell, lane)
+    if sample is None:
         return
-    elif not library.raw_ubam.exists():
-        raise ValueError(f"{library.raw_ubam} does not exist")
+    else:
+        for barcode_ubam in sample.barcode_ubams:
+            if not barcode_ubam.exists():
+                raise ValueError(f"{barcode_ubam} does not exist")
 
     # create a subdirectory for alignment
-    (library.lane_dir / "alignment").mkdir(exist_ok=True)
+    (sample.lane_dir / "alignment").mkdir(exist_ok=True)
 
-    bead_structure = library.get_bead_structure()
+    bead_structure = sample.get_bead_structure()
     xc_range = ":".join(f"{i}-{j}" for c, i, j in bead_structure if c == "C")
     xm_range = ":".join(f"{i}-{j}" for c, i, j in bead_structure if c == "M")
+
+    # if multiple barcodes correspond to one sample, merge them
+    if len(sample.barcode_ubams) > 1:
+        cmd = config.picard_cmd("MergeSamFiles", manifest.tmp_dir)
+        cmd.extend(
+            [
+                "--OUTPUT",
+                sample.raw_ubam,
+                "--SORT_ORDER",
+                "unsorted",
+                "--ASSUME_SORTED",
+                "true",
+            ]
+        )
+
+        for ubam_file in sample.barcode_ubams:
+            cmd.extend(["--INPUT", ubam_file])
+
+        run_command(cmd, "MergeBamFiles", sample)
+    else:
+        # otherwise, just rename the file
+        os.rename(sample.barcode_ubams[0], sample.raw_ubam)
 
     procs = []
 
     cmd = config.dropseq_cmd(
         "TagBamWithReadSequenceExtended",
-        library.raw_ubam,
+        sample.raw_ubam,
         "/dev/stdout",
         manifest.tmp_dir,
     )
     cmd.extend(
         [
-            f"SUMMARY={library.cellular_tagged_summary}",
+            f"SUMMARY={sample.cellular_tagged_summary}",
             f"BASE_RANGE={xc_range}",
-            f"BASE_QUALITY={library.base_quality}",
+            f"BASE_QUALITY={sample.base_quality}",
             "BARCODED_READ=1",
             "DISCARD_READ=false",
             "TAG_NAME=XC",
@@ -87,7 +111,7 @@ def main(
         start_popen(
             cmd,
             "TagBamWithReadSequenceExtended (Cellular)",
-            library,
+            sample,
             lane,
         )
     )
@@ -98,9 +122,9 @@ def main(
     )
     cmd.extend(
         [
-            f"SUMMARY={library.molecular_tagged_summary}",
+            f"SUMMARY={sample.molecular_tagged_summary}",
             f"BASE_RANGE={xm_range}",
-            f"BASE_QUALITY={library.base_quality}",
+            f"BASE_QUALITY={sample.base_quality}",
             "BARCODED_READ=1",
             "DISCARD_READ=true",
             "TAG_NAME=XM",
@@ -111,7 +135,7 @@ def main(
         start_popen(
             cmd,
             "TagBamWithReadSequenceExtended (Molecular)",
-            library,
+            sample,
             lane,
             procs[-1],
         )
@@ -121,38 +145,38 @@ def main(
     cmd = config.dropseq_cmd("FilterBam", "/dev/stdin", "/dev/stdout", manifest.tmp_dir)
     cmd.extend(["PASSING_READ_THRESHOLD=0.1", "TAG_REJECT=XQ"])
 
-    procs.append(start_popen(cmd, "FilterBam", library, lane, procs[-1]))
+    procs.append(start_popen(cmd, "FilterBam", sample, lane, procs[-1]))
 
-    if library.start_sequence != constants.NO_START_SEQUENCE:
+    if sample.start_sequence != constants.NO_START_SEQUENCE:
         # Trim reads with starting sequence
         cmd = config.dropseq_cmd(
             "TrimStartingSequence", "/dev/stdin", "/dev/stdout", manifest.tmp_dir
         )
         cmd.extend(
             [
-                f"OUTPUT_SUMMARY={library.trimming_summary}",
-                f"SEQUENCE={library.start_sequence}",
+                f"OUTPUT_SUMMARY={sample.trimming_summary}",
+                f"SEQUENCE={sample.start_sequence}",
                 "MISMATCHES=0",
                 "NUM_BASES=5",
             ]
         )
 
-        procs.append(start_popen(cmd, "TrimStartingSequence", library, lane, procs[-1]))
+        procs.append(start_popen(cmd, "TrimStartingSequence", sample, lane, procs[-1]))
 
     # Adapter-aware poly A trimming
     cmd = config.dropseq_cmd(
-        "PolyATrimmer", "/dev/stdin", library.polya_filtered_ubam, manifest.tmp_dir
+        "PolyATrimmer", "/dev/stdin", sample.polya_filtered_ubam, manifest.tmp_dir
     )
     cmd.extend(
         [
-            f"OUTPUT_SUMMARY={library.polya_filtering_summary}",
+            f"OUTPUT_SUMMARY={sample.polya_filtering_summary}",
             "MISMATCHES=0",
             "NUM_BASES=6",
             "USE_NEW_TRIMMER=true",
         ]
     )
 
-    procs.append(start_popen(cmd, "PolyATrimmer", library, lane, procs[-1]))
+    procs.append(start_popen(cmd, "PolyATrimmer", sample, lane, procs[-1]))
 
     # close intermediate streams
     for p in procs[:-1]:
@@ -167,24 +191,24 @@ def main(
     cmd.extend(
         [
             "-I",
-            library.polya_filtered_ubam,
+            sample.polya_filtered_ubam,
             "-F",
-            library.polya_filtered_fastq,
+            sample.polya_filtered_fastq,
         ]
     )
-    run_command(cmd, "SamToFastq", library, lane)
+    run_command(cmd, "SamToFastq", sample, lane)
 
     # Map reads to genome sequence using STAR
     cmd = [
         "STAR",
         "--genomeDir",
-        library.reference.genome_dir,
+        sample.reference.genome_dir,
         "--readFilesIn",
-        library.polya_filtered_fastq,
+        sample.polya_filtered_fastq,
         "--readFilesCommand",
         "zcat",
         "--outFileNamePrefix",
-        library.star_prefix,
+        sample.star_prefix,
         "--outStd",
         "Log",
         "--outSAMtype",
@@ -198,14 +222,14 @@ def main(
         "8",
     ]
 
-    run_command(cmd, "STAR", library, lane)
+    run_command(cmd, "STAR", sample, lane)
 
     # Check alignments quality
     log.debug(
-        f"Writing alignment statistics for {library.aligned_bam} to"
-        f" {library.alignment_pickle}"
+        f"Writing alignment statistics for {sample.aligned_bam} to"
+        f" {sample.alignment_pickle}"
     )
-    write_alignment_stats(library.aligned_bam, library.alignment_pickle)
+    write_alignment_stats(sample.aligned_bam, sample.alignment_pickle)
 
     procs = []
 
@@ -214,23 +238,23 @@ def main(
     cmd.extend(
         [
             "-I",
-            library.aligned_bam,
+            sample.aligned_bam,
             "-O",
             "/dev/stdout",
             "--SORT_ORDER",
             "queryname",
         ]
     )
-    procs.append(start_popen(cmd, "SortSam", library, lane))
+    procs.append(start_popen(cmd, "SortSam", sample, lane))
 
     # Merge unmapped bam and aligned bam
     cmd = config.picard_cmd("MergeBamAlignment", manifest.tmp_dir, mem="24g")
     cmd.extend(
         [
             "-R",
-            library.reference.fasta,
+            sample.reference.fasta,
             "--UNMAPPED",
-            library.polya_filtered_ubam,
+            sample.polya_filtered_ubam,
             "--ALIGNED",
             "/dev/stdin",
             "-O",
@@ -244,29 +268,29 @@ def main(
         ]
     )
 
-    procs.append(start_popen(cmd, "MergeBamAlignment", library, lane, procs[-1]))
+    procs.append(start_popen(cmd, "MergeBamAlignment", sample, lane, procs[-1]))
 
     # Tag read with interval
     cmd = config.dropseq_cmd(
         "TagReadWithInterval", "/dev/stdin", "/dev/stdout", manifest.tmp_dir
     )
-    cmd.extend([f"INTERVALS={library.reference.intervals}", "TAG=XG"])
+    cmd.extend([f"INTERVALS={sample.reference.intervals}", "TAG=XG"])
 
-    procs.append(start_popen(cmd, "TagReadWithInterval", library, lane, procs[-1]))
+    procs.append(start_popen(cmd, "TagReadWithInterval", sample, lane, procs[-1]))
 
     # Tag read with gene function
     cmd = config.dropseq_cmd(
         "TagReadWithGeneFunction",
         "/dev/stdin",
-        library.processed_bam,
+        sample.processed_bam,
         manifest.tmp_dir,
         compression=5,
     )
     cmd.extend(
-        [f"ANNOTATIONS_FILE={library.reference.annotations}", "CREATE_INDEX=false"]
+        [f"ANNOTATIONS_FILE={sample.reference.annotations}", "CREATE_INDEX=false"]
     )
 
-    procs.append(start_popen(cmd, "TagReadWithGeneFunction", library, lane, procs[-1]))
+    procs.append(start_popen(cmd, "TagReadWithGeneFunction", sample, lane, procs[-1]))
 
     # close intermediate streams
     for p in procs[:-1]:
@@ -277,16 +301,16 @@ def main(
     log.debug("Finished with post-alignment processing")
 
     # removed unneeded files
-    os.remove(library.polya_filtered_ubam)
-    os.remove(library.polya_filtered_fastq)
-    os.remove(library.aligned_bam)
+    os.remove(sample.polya_filtered_ubam)
+    os.remove(sample.polya_filtered_fastq)
+    os.remove(sample.aligned_bam)
 
     log.debug("Setting group permissions")
-    give_group_access(library.dir)
+    give_group_access(sample.dir)
     log.debug("Copying data to google storage")
     rsync_to_google(
-        library.lane_dir,
-        config.gs_path / library.lane_dir.relative_to(config.library_dir),
+        sample.lane_dir,
+        config.gs_path / sample.lane_dir.relative_to(config.library_dir),
     )
 
-    log.info(f"Alignment for {library} completed")
+    log.info(f"Alignment for {sample} completed")

--- a/src/slideseq/pipeline/alignment.py
+++ b/src/slideseq/pipeline/alignment.py
@@ -29,7 +29,7 @@ log = logging.getLogger(__name__)
 @click.option(
     "--manifest-file",
     type=click.Path(exists=True, file_okay=True, dir_okay=False),
-    help="YAML file containing the flowcell manifest",
+    help="YAML file containing the manifest",
 )
 @click.option("--debug", is_flag=True, help="Turn on debug logging")
 @click.option("--log-file", type=click.Path(exists=False))

--- a/src/slideseq/pipeline/alignment.py
+++ b/src/slideseq/pipeline/alignment.py
@@ -16,6 +16,7 @@ log = logging.getLogger(__name__)
 
 
 @click.command(name="align_library", no_args_is_help=True)
+@click.option("--flowcell", type=int, required=True, help="Flowcell being aligned")
 @click.option(
     "--lane", type=int, required=True, help="Lane of the flowcell being aligned"
 )
@@ -34,6 +35,7 @@ log = logging.getLogger(__name__)
 @click.option("--debug", is_flag=True, help="Turn on debug logging")
 @click.option("--log-file", type=click.Path(exists=False))
 def main(
+    flowcell: str,
     lane: int,
     library_index: int,
     manifest_file: str,
@@ -47,7 +49,7 @@ def main(
     manifest = Manifest.from_file(Path(manifest_file))
 
     # task array is 1-indexed
-    library = manifest.get_library_lane(library_index - 1, lane)
+    library = manifest.get_library_lane(library_index - 1, flowcell, lane)
     if library is None:
         return
     elif not library.raw_ubam.exists():

--- a/src/slideseq/pipeline/alignment.py
+++ b/src/slideseq/pipeline/alignment.py
@@ -282,6 +282,9 @@ def main(
     log.debug("Setting group permissions")
     give_group_access(library.dir)
     log.debug("Copying data to google storage")
-    rsync_to_google(library.dir, config.gs_path)
+    rsync_to_google(
+        library.lane_dir,
+        config.gs_path / library.lane_dir.relative_to(config.library_dir),
+    )
 
     log.info(f"Alignment for {library} completed")

--- a/src/slideseq/pipeline/preparation.py
+++ b/src/slideseq/pipeline/preparation.py
@@ -77,10 +77,6 @@ def validate_demux(manifest: Manifest):
         log.error(f"{manifest.workflow_dir} does not exist")
         return False
 
-    if not manifest.metadata_file.exists():
-        log.error(f"{manifest.metadata_file} does not exist")
-        return False
-
     for flowcell_dir in manifest.flowcell_dirs:
         run_info = get_run_info(flowcell_dir)
 

--- a/src/slideseq/pipeline/preparation.py
+++ b/src/slideseq/pipeline/preparation.py
@@ -59,7 +59,7 @@ def prepare_demux(
 
         for lane in run_info.lanes:
             output_lane_dir = workflow_dir / run_info.flowcell / f"L{lane:03d}"
-            output_lane_dir.mkdir(exist_ok=True)
+            output_lane_dir.mkdir(exist_ok=True, parents=True)
             (output_lane_dir / "barcodes").mkdir(exist_ok=True)
 
             # Generate barcode_params.txt that is needed by ExtractIlluminaBarcodes

--- a/src/slideseq/pipeline/processing.py
+++ b/src/slideseq/pipeline/processing.py
@@ -185,7 +185,7 @@ def calc_alignment_metrics(
 @click.option(
     "--manifest-file",
     type=click.Path(exists=True, file_okay=True, dir_okay=False),
-    help="YAML file containing the flowcell manifest",
+    help="YAML file containing the manifest",
 )
 @click.option("--debug", is_flag=True, help="Turn on debug logging")
 @click.option("--log-file", type=click.Path(exists=False))

--- a/src/slideseq/pipeline/processing.py
+++ b/src/slideseq/pipeline/processing.py
@@ -322,6 +322,6 @@ def main(
     log.debug("Setting group permissions")
     give_group_access(library.dir)
     log.debug("Copying data to google storage")
-    rsync_to_google(library.dir, config.gs_path)
+    rsync_to_google(library.dir, config.gs_path / library.date_name)
 
     log.info(f"Processing for {library} complete")

--- a/src/slideseq/pipeline/submit_slideseq.py
+++ b/src/slideseq/pipeline/submit_slideseq.py
@@ -164,20 +164,24 @@ def main(
         if dryrun:
             log.info(f"Would write following in {metadata_file}")
             log.info(run_df)
-        elif demux:
-            # make various directories
-            prepare_demux(
-                run_df, run_info_list, manifest.workflow_dir, manifest.library_dir
-            )
+        else:
+            if demux:
+                # make various directories
+                prepare_demux(
+                    run_df, run_info_list, manifest.workflow_dir, manifest.library_dir
+                )
+            elif not validate_demux(manifest):
+                # appears that demux was not run previously
+                run_errors.add(run_name)
+                continue
+            elif not (align or validate_alignment(manifest, n_libraries)):
+                # appears that alignment was not run and wasn't requested
+                run_errors.add(run_name)
+                continue
+
+            if metadata_file.exists():
+                log.info(f"Overwriting metadata file {metadata_file}")
             run_df.to_csv(metadata_file, header=True, index=False)
-        elif not validate_demux(manifest):
-            # appears that demux was not run previously
-            run_errors.add(run_name)
-            continue
-        elif not (align or validate_alignment(manifest, n_libraries)):
-            # appears that alignment was not run and wasn't requested
-            run_errors.add(run_name)
-            continue
 
         demux_jids = dict()
 

--- a/src/slideseq/pipeline/submit_slideseq.py
+++ b/src/slideseq/pipeline/submit_slideseq.py
@@ -191,10 +191,10 @@ def main(
                     log_file=manifest.log_dir / run_info.demux_log,
                     PICARD_JAR=config.picard,
                     TMP_DIR=manifest.tmp_dir,
+                    FLOWCELL=run_info.flowcell,
                     BASECALLS_DIR=run_info.basecall_dir,
                     READ_STRUCTURE=run_info.read_structure,
                     OUTPUT_DIR=output_dir,
-                    RUN_BARCODE=run_name,
                 )
                 demux_args.extend(
                     [
@@ -236,6 +236,7 @@ def main(
                         log_file=manifest.log_dir / run_info.alignment_log(lane),
                         debug=debug,
                         CONDA_ENV=env_name,
+                        FLOWCELL=run_info.flowcell,
                         LANE=lane,
                         MANIFEST=manifest_file,
                     )

--- a/src/slideseq/scripts/alignment.sh
+++ b/src/slideseq/scripts/alignment.sh
@@ -28,6 +28,7 @@ fi
 
 # this will run slideseq.pipeline.alignment:main
 align_library ${DEBUG} \
+  --flowcell ${FLOWCELL} \
   --lane ${LANE} \
   --library-index ${SGE_TASK_ID} \
   --manifest-file ${MANIFEST}

--- a/src/slideseq/scripts/demultiplex.sh
+++ b/src/slideseq/scripts/demultiplex.sh
@@ -27,7 +27,7 @@ java -Djava.io.tmpdir=${TMP_DIR} -XX:+UseParallelGC \
   --BASECALLS_DIR ${BASECALLS_DIR} \
   --READ_STRUCTURE ${READ_STRUCTURE}
 
-# extract barcodes to $BARCODE_FILE
+# extract barcodes
 java -Djava.io.tmpdir=${TMP_DIR} -XX:+UseParallelGC \
   -XX:GCTimeLimit=20 -XX:GCHeapFreeLimit=10 -Xms64g -Xmx124g \
   -jar ${PICARD_JAR} ExtractIlluminaBarcodes \
@@ -35,9 +35,9 @@ java -Djava.io.tmpdir=${TMP_DIR} -XX:+UseParallelGC \
   --LANE ${SGE_TASK_ID} \
   --BASECALLS_DIR ${BASECALLS_DIR} \
   --READ_STRUCTURE ${READ_STRUCTURE} \
-  --OUTPUT_DIR ${OUTPUT_DIR}/L00${SGE_TASK_ID}/barcodes \
-  --BARCODE_FILE ${OUTPUT_DIR}/L00${SGE_TASK_ID}/barcode_params.txt \
-  --METRICS_FILE ${OUTPUT_DIR}/L00${SGE_TASK_ID}/${RUN_BARCODE}.barcode_metrics.txt \
+  --OUTPUT_DIR ${OUTPUT_DIR}/${FLOWCELL}/L00${SGE_TASK_ID}/barcodes \
+  --BARCODE_FILE ${OUTPUT_DIR}/${FLOWCELL}/L00${SGE_TASK_ID}/barcode_params.txt \
+  --METRICS_FILE ${OUTPUT_DIR}/${FLOWCELL}/L00${SGE_TASK_ID}/${FLOWCELL}.barcode_metrics.txt \
   --COMPRESS_OUTPUTS true \
   --NUM_PROCESSORS 8
 
@@ -49,9 +49,9 @@ java -Djava.io.tmpdir=${TMP_DIR} -XX:+UseParallelGC \
   --LANE ${SGE_TASK_ID} \
   --BASECALLS_DIR ${BASECALLS_DIR} \
   --READ_STRUCTURE ${READ_STRUCTURE} \
-  --RUN_BARCODE ${RUN_BARCODE} \
-  --BARCODES_DIR ${OUTPUT_DIR}/L00${SGE_TASK_ID}/barcodes \
-  --LIBRARY_PARAMS ${OUTPUT_DIR}/L00${SGE_TASK_ID}/library_params.txt \
+  --RUN_BARCODE ${FLOWCELL} \
+  --BARCODES_DIR ${OUTPUT_DIR}/${FLOWCELL}/L00${SGE_TASK_ID}/barcodes \
+  --LIBRARY_PARAMS ${OUTPUT_DIR}/${FLOWCELL}/L00${SGE_TASK_ID}/library_params.txt \
   --INCLUDE_NON_PF_READS false \
   --APPLY_EAMSS_FILTER false \
   --ADAPTERS_TO_CHECK null \

--- a/src/slideseq/util/__init__.py
+++ b/src/slideseq/util/__init__.py
@@ -73,7 +73,7 @@ def rsync_to_google(path: Path, gs_path: Path):
         "setmeta",
         "-h",
         f"Custom-Time:{date}",
-        f"{gs_path}/{path.name}/**bam",
+        f"gs://{gs_path}/**bam",
     ]
     proc = run(cmd, capture_output=True, text=True)
     if proc.returncode != 0:

--- a/src/slideseq/util/__init__.py
+++ b/src/slideseq/util/__init__.py
@@ -30,7 +30,14 @@ def give_group_access(path: Path):
             os.chmod(os.path.join(dirpath, filename), 0o664)
 
 
-def rsync_to_google(path: Path, gs_path: str):
+def rsync_to_google(path: Path, gs_path: Path):
+    """
+    Call gsutil rsync to upload a directory up to Google Storage, and sets Custom-Time
+    metadata on BAM files for lifecycle rules.
+
+    :param path: Local path to upload
+    :param gs_path: Path to the destination, including bucket name but *not* 'gs://'
+    """
     # -m for multithreading
     # -q to quiet output
     # -C to continue on errors
@@ -45,7 +52,7 @@ def rsync_to_google(path: Path, gs_path: str):
         "-e",
         "-r",
         f"{path}",
-        f"{gs_path}/{path.name}",
+        f"gs://{gs_path}",
     ]
 
     proc = run(cmd, capture_output=True, text=True)

--- a/src/slideseq/util/__init__.py
+++ b/src/slideseq/util/__init__.py
@@ -55,12 +55,7 @@ def rsync_to_google(path: Path, gs_path: Path):
         f"gs://{gs_path}",
     ]
 
-    proc = run(cmd, capture_output=True, text=True)
-    if proc.returncode != 0:
-        log.error(f"Error running gsutil rsync:\n\t{proc.stderr}")
-        sys.exit(1)
-    else:
-        log.info("gsutil rsync completed")
+    run_command(cmd, "gsutil rsync", path)
 
     date = datetime.datetime.now(tz=datetime.timezone.utc).strftime(
         "%Y-%m-%dT%H:%M:%SZ"
@@ -75,12 +70,8 @@ def rsync_to_google(path: Path, gs_path: Path):
         f"Custom-Time:{date}",
         f"gs://{gs_path}/**bam",
     ]
-    proc = run(cmd, capture_output=True, text=True)
-    if proc.returncode != 0:
-        log.error(f"Error running gsutil setmeta:\n\t{proc.stderr}")
-        sys.exit(1)
-    else:
-        log.info("gsutil setmeta completed")
+
+    run_command(cmd, "gsutil setmeta", path)
 
 
 def qsub_args(log_file: Path = None, debug: bool = False, **kwargs: Any) -> list[str]:
@@ -110,7 +101,7 @@ def qsub_args(log_file: Path = None, debug: bool = False, **kwargs: Any) -> list
     return arg_list
 
 
-def run_command(cmd: list[Any], name: str, library: lib.Library, lane: int = None):
+def run_command(cmd: list[Any], name: str, library: Any, lane: int = None):
     if lane is None:
         log.info(f"{name} for {library}")
     else:

--- a/src/slideseq/util/constants.py
+++ b/src/slideseq/util/constants.py
@@ -1,6 +1,8 @@
 # number of times to try qsub before giving up
 MAX_QSUB = 3
 
+# string used to mean "demux all lanes for this sample"
+ALL_LANES = "{LANE}"
 
 # these biotypes are _removed_ from the reference GTF
 FILTERED_BIOTYPES = [

--- a/src/slideseq/util/constants.py
+++ b/src/slideseq/util/constants.py
@@ -4,6 +4,9 @@ MAX_QSUB = 3
 # string used to mean "demux all lanes for this sample"
 ALL_LANES = "{LANE}"
 
+# string used to mean "no starting sequence to trim" (used for 10x runs)
+NO_START_SEQUENCE = "no start sequence"
+
 # these biotypes are _removed_ from the reference GTF
 FILTERED_BIOTYPES = [
     "processed_pseudogene",
@@ -50,7 +53,7 @@ METADATA_COLS = [
 # a single library can span multiple rows in the sequencing spreadsheet,
 # e.g. multiple flowcells, lanes, and sample barcodes. But the rest of the columns
 # should be constant for consistent processing
-VARIABLE_LIBRARY_COLS = {"bclpath", "flowcell", "lane", "sample_barcode"}
+VARIABLE_LIBRARY_COLS = ["bclpath", "flowcell", "lane", "sample_barcode"]
 
 
 # for columns that pandas might not recognize automatically

--- a/src/slideseq/util/constants.py
+++ b/src/slideseq/util/constants.py
@@ -28,6 +28,7 @@ METADATA_COLS = [
     "library",
     "date",
     "flowcell",
+    "run_name",
     "BCLPath",
     "lane",
     "sample_barcode",
@@ -44,6 +45,12 @@ METADATA_COLS = [
     "gen_read1_plot",
     "gen_downsampling",
 ]
+
+
+# a single library can span multiple rows in the sequencing spreadsheet,
+# e.g. multiple flowcells, lanes, and sample barcodes. But the rest of the columns
+# should be constant for consistent processing
+VARIABLE_LIBRARY_COLS = {"bclpath", "lane", "sample_barcode"}
 
 
 # for columns that pandas might not recognize automatically

--- a/src/slideseq/util/constants.py
+++ b/src/slideseq/util/constants.py
@@ -50,7 +50,7 @@ METADATA_COLS = [
 # a single library can span multiple rows in the sequencing spreadsheet,
 # e.g. multiple flowcells, lanes, and sample barcodes. But the rest of the columns
 # should be constant for consistent processing
-VARIABLE_LIBRARY_COLS = {"bclpath", "lane", "sample_barcode"}
+VARIABLE_LIBRARY_COLS = {"bclpath", "flowcell", "lane", "sample_barcode"}
 
 
 # for columns that pandas might not recognize automatically

--- a/src/slideseq/util/run_info.py
+++ b/src/slideseq/util/run_info.py
@@ -1,0 +1,85 @@
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from xml.etree import ElementTree as et
+
+log = logging.getLogger(__name__)
+
+
+def get_flowcell(run_info: et.ElementTree) -> str:
+    """
+    Get the flowcell name from RunInfo.xml. This should be more reliable than
+    trying to parse the run directory, which might have been renamed.
+
+    :param run_info: ElementTree representing RunInfo.xml
+    :return: The flowcell name for this run
+    """
+    flowcell = run_info.find("./Run/Flowcell").text
+    return flowcell
+
+
+def get_read_structure(run_info: et.ElementTree) -> str:
+    """
+    Get read structure from RunInfo.xml. Assumes one index sequence only,
+    will warn if two are present and ignore the second.
+
+    :param run_info: ElementTree representing RunInfo.xml
+    :return: Formatting string representing the read structure
+    """
+    read_elems = run_info.findall("./Run/Reads/Read[@NumCycles][@Number]")
+    read_elems.sort(key=lambda el: int(el.get("Number")))
+
+    if len(read_elems) == 4:
+        # two index reads. We will just ignore the second index
+        log.warning(
+            "This sequencing run has two index reads, we are ignoring the second one"
+        )
+        return "{}T{}B{}S{}T".format(*(el.get("NumCycles") for el in read_elems))
+    elif len(read_elems) != 3:
+        raise ValueError(f"Expected three reads, got {len(read_elems)}")
+
+    return "{}T{}B{}T".format(*(el.get("NumCycles") for el in read_elems))
+
+
+def get_lanes(run_info: et.ElementTree) -> range:
+    """
+    Return the lanes for this run, as a range
+    :param run_info: ElementTree representing RunInfo.xml
+    :return: range object for the lanes of the run
+    """
+    lane_count = int(run_info.find("./Run/FlowcellLayout[@LaneCount]").get("LaneCount"))
+    return range(1, lane_count + 1)
+
+
+@dataclass
+class RunInfo:
+    """A dataclass to represent RunInfo.xml for a sequencing run (a.k.a. flowcell)"""
+
+    run_dir: Path
+    flowcell: str
+    lanes: range
+    read_structure: str
+
+    @property
+    def demux_log(self):
+        return f"demultiplex.{self.flowcell}.L00$TASK_ID.log"
+
+    @property
+    def basecall_dir(self):
+        return self.run_dir / "Data" / "Intensities" / "BaseCalls"
+
+    def alignment_log(self, lane: int):
+        return f"alignment.{self.flowcell}.L{lane:03d}.$TASK_ID.log"
+
+
+def get_run_info(run_dir: Path) -> RunInfo:
+    # open the RunInfo.xml file and parse it with element tree
+    with (run_dir / "RunInfo.xml").open() as f:
+        run_info = et.parse(f)
+
+    return RunInfo(
+        run_dir,
+        get_flowcell(run_info),
+        get_lanes(run_info),
+        get_read_structure(run_info),
+    )


### PR DESCRIPTION
Quite a large change, led to version bump to 0.2.3 (which I accidentally pushed to master instead).

This PR allows multiple flowcells to be run as one library, merging based on the library name. It _also_ allows for multiple _barcodes_ to be merged in a single library, for example when 10X samples are being run through the pipeline for analysis.

A fair amount of refactoring of the `Library` and `Sample` (née LibraryLane) classes made this possible. There is a new column in the google sheet for `run_name`, which is how runs should be submitted from now on (this is essentially how we used `flowcell`, as it was often not the actual flowcell of the run).