### PR TITLE
added downsampling as a separate job

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,4 +2,5 @@ include src/slideseq/config.yaml
 include src/slideseq/scripts/demultiplex.sh
 include src/slideseq/scripts/alignment.sh
 include src/slideseq/scripts/processing.sh
+include src/slideseq/scripts/downsampling.sh
 include src/slideseq/scripts/build_reference.sh

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,7 @@ setuptools.setup(
             "submit_slideseq = slideseq.pipeline.submit_slideseq:main",
             "align_library = slideseq.pipeline.alignment:main",
             "process_library = slideseq.pipeline.processing:main",
+            "downsample_library = slideseq.pipeline.downsampling:main",
             "build_ref = slideseq.pipeline.reference:main",
             "plot_barcodes = slideseq.scripts.plot_barcodes:main",
             "barcode_matrix = slideseq.scripts.barcode_matrix:main",

--- a/src/slideseq/pipeline/downsampling.py
+++ b/src/slideseq/pipeline/downsampling.py
@@ -1,9 +1,15 @@
 import logging
+import os
 from pathlib import Path
 
-from slideseq.config import Config
+import click
+
+from slideseq.config import Config, get_config
 from slideseq.library import Library
-from slideseq.util import run_command
+from slideseq.metadata import Manifest
+from slideseq.plot.plot_downsampling import plot_downsampling
+from slideseq.util import give_group_access, rsync_to_google, run_command
+from slideseq.util.logger import create_logger
 
 log = logging.getLogger(__name__)
 
@@ -12,6 +18,7 @@ def downsample_dge(
     config: Config,
     bam_file: Path,
     downsampled_bam: Path,
+    cell_tag: str,
     library: Library,
     ratio: float,
     tmp_dir: Path,
@@ -39,7 +46,7 @@ def downsample_dge(
     cmd = config.dropseq_cmd("DigitalExpression", downsampled_bam, "/dev/null", tmp_dir)
     cmd.extend(
         [
-            "CELL_BARCODE_TAG=XC",
+            f"CELL_BARCODE_TAG={cell_tag}",
             f"SUMMARY={digital_expression_summary}",
             f"MIN_NUM_TRANSCRIPTS_PER_CELL={library.min_transcripts_per_cell}",
             f"READ_MQ={library.base_quality}",
@@ -57,3 +64,85 @@ def downsample_dge(
     log.debug(f"Finished with downsampling at ratio {ratio:.1f}")
 
     return ratio, digital_expression_summary
+
+
+@click.command("downsample_library")
+@click.option(
+    "-i",
+    "--library-index",
+    type=int,
+    required=True,
+    help="Which sample from the metadata to align",
+)
+@click.option(
+    "--manifest-file",
+    type=click.Path(exists=True, file_okay=True, dir_okay=False),
+    help="YAML file containing the manifest",
+)
+@click.option("--debug", is_flag=True, help="Turn on debug logging")
+@click.option("--log-file", type=click.Path(exists=False))
+def main(
+    library_index: int, manifest_file: str, debug: bool = False, log_file: str = None
+):
+    create_logger(debug=debug, log_file=log_file)
+    config = get_config()
+
+    log.debug(f"Reading manifest from {manifest_file}")
+    manifest = Manifest.from_file(Path(manifest_file))
+
+    # task array is 1-indexed
+    library = manifest.get_library(library_index - 1)
+
+    if not library.gen_downsampling:
+        log.debug("Downsampling not requested, nothing to do")
+        return
+
+    log.info(f"Downsampling alignments for library {library.name}")
+    library.downsample_dir.mkdir(exist_ok=True, parents=True)
+
+    if library.run_barcodematching:
+        # this will be much faster on matched bams
+        downsample_input = library.matched
+        downsample_tag = "XB"
+    else:
+        downsample_input = library.merged
+        downsample_tag = "XC"
+
+    downsample_output = []
+
+    # Progressively downsample the BAM from largest to smallest
+    input_bam = downsample_input.bam
+    for ratio in range(9, 0, -1):
+        downsampled_bam = downsample_input.downsampled_bam(ratio)
+        downsample_output.append(
+            downsample_dge(
+                config=config,
+                bam_file=input_bam,
+                downsampled_bam=downsampled_bam,
+                cell_tag=downsample_tag,
+                library=library,
+                ratio=ratio / 10,
+                tmp_dir=manifest.tmp_dir,
+            )
+        )
+        if input_bam != downsample_input.bam:
+            os.remove(input_bam)
+        input_bam = downsampled_bam
+
+    # remove final downsampled_bam
+    if input_bam != downsample_input.bam:
+        os.remove(input_bam)
+
+    plot_downsampling(
+        downsample_output,
+        downsample_input.digital_expression_summary,
+        downsample_input.downsampling_pdf,
+    )
+
+    log.debug("Setting group permissions")
+    give_group_access(library.dir)
+    if config.gs_path is not None:
+        log.debug("Copying data to google storage")
+        rsync_to_google(library.dir, config.gs_path / library.date_name)
+
+    log.info(f"Downsampling for {library} complete")

--- a/src/slideseq/pipeline/downsampling.py
+++ b/src/slideseq/pipeline/downsampling.py
@@ -113,7 +113,7 @@ def main(
     # Progressively downsample the BAM from largest to smallest
     input_bam = downsample_input.bam
     for ratio in range(9, 0, -1):
-        downsampled_bam = downsample_input.downsampled_bam(ratio)
+        downsampled_bam = downsample_input.downsampled_bam(ratio / 10)
         downsample_output.append(
             downsample_dge(
                 config=config,

--- a/src/slideseq/pipeline/downsampling.py
+++ b/src/slideseq/pipeline/downsampling.py
@@ -112,8 +112,10 @@ def main(
 
     # Progressively downsample the BAM from largest to smallest
     input_bam = downsample_input.bam
-    for ratio in range(9, 0, -1):
-        downsampled_bam = downsample_input.downsampled_bam(ratio / 10)
+    for n in range(9, 0, -1):
+        ratio = n / 10
+
+        downsampled_bam = downsample_input.downsampled_bam(ratio)
         downsample_output.append(
             downsample_dge(
                 config=config,
@@ -121,10 +123,11 @@ def main(
                 downsampled_bam=downsampled_bam,
                 cell_tag=downsample_tag,
                 library=library,
-                ratio=ratio / 10,
+                ratio=ratio,
                 tmp_dir=manifest.tmp_dir,
             )
         )
+
         if input_bam != downsample_input.bam:
             os.remove(input_bam)
         input_bam = downsampled_bam

--- a/src/slideseq/plot/plot_downsampling.py
+++ b/src/slideseq/plot/plot_downsampling.py
@@ -19,8 +19,6 @@ def calculate_quintiles(umis_per_bc: list[int], percentiles: np.ndarray):
     total_umis = sum(umis_per_bc)
     n_bcs = len(umis_per_bc)
 
-    print(total_umis, n_bcs)
-
     # how this works: umis_per_bc is in descending order. We reverse it,
     # then calculate the cumulative sum. The percentiles of that sum are
     # equal to the total reads from the bottom 20%, 40%, etc. We subtract

--- a/src/slideseq/scripts/downsampling.sh
+++ b/src/slideseq/scripts/downsampling.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+#$ -N downsampling
+#$ -l os=RedHat7
+#$ -l h_vmem=16G
+#$ -l h_rt=96:0:0
+#$ -pe smp 2
+#$ -binding linear:2
+#$ -terse
+#$ -notify
+#$ -P macosko_lab
+#$ -R y
+#$ -j y
+#$ -m eas
+
+source /broad/software/scripts/useuse
+reuse Anaconda3
+reuse Java-1.8
+reuse Google-Cloud-SDK
+
+set -e
+
+if [ -z "${CONDA_ENV}" ]; then
+  echo "Error: conda environment is not set"
+  exit 1
+else
+  source activate ${CONDA_ENV}
+fi
+
+# do whatever post-processing is needed
+downsample_library ${DEBUG} \
+  --library-index ${SGE_TASK_ID} \
+  --manifest-file ${MANIFEST}


### PR DESCRIPTION
downsampling the BAM can be quite slow, so this PR splits it off into a separate job that is submitted via `qsub`. The main benefit is that we can be confident that the processing job completed successfully even if downsampling times out. Another benefit is that we can potentially lower the time limit on the processing job, which needs more compute resources.

This also fixes a bug in the downsampling code–we were using the matched barcodes for the 100% numbers but the unmatched (raw) barcodes for the downsampled numbers.