### PR TITLE
project_name in config file

### DIFF
--- a/src/slideseq/config.py
+++ b/src/slideseq/config.py
@@ -13,6 +13,7 @@ log = logging.getLogger(__name__)
 
 @dataclass
 class Config:
+    project_name: str
     picard: Path
     dropseq_dir: Path
     reference_dir: Path
@@ -31,6 +32,7 @@ class Config:
         log.debug(f"Read config file {input_file}")
 
         return Config(
+            project_name=data["project_name"] or None,
             picard=Path(data["picard"]),
             dropseq_dir=Path(data["dropseq_dir"]),
             reference_dir=Path(data["reference_dir"]),

--- a/src/slideseq/config.yaml
+++ b/src/slideseq/config.yaml
@@ -1,3 +1,4 @@
+project_name: macosko_lab
 picard: /seq/software/picard-public/2.24.2/picard.jar
 dropseq_dir: /broad/macosko/bin/dropseq-tools-2.4.0
 reference_dir: /broad/macosko/reference

--- a/src/slideseq/pipeline/reference.py
+++ b/src/slideseq/pipeline/reference.py
@@ -136,6 +136,7 @@ def main(
         slideseq.scripts, "build_reference.sh"
     ) as qsub_script:
         mkref_args = qsub_args(
+            project_name=config.project_name,
             log_file=output_dir / "build_reference.log",
             CONDA_ENV=env_name,
             PICARD_JAR=config.picard,

--- a/src/slideseq/pipeline/submit_slideseq.py
+++ b/src/slideseq/pipeline/submit_slideseq.py
@@ -185,6 +185,7 @@ def main(
         ) as qsub_script:
             for run_info in run_info_list:
                 demux_args = qsub_args(
+                    project_name=config.project_name,
                     log_file=manifest.log_dir / run_info.demux_log,
                     email=",".join(manifest.email_addresses),
                     PICARD_JAR=config.picard,
@@ -231,6 +232,7 @@ def main(
                         continue
 
                     alignment_args = qsub_args(
+                        project_name=config.project_name,
                         log_file=manifest.log_dir / run_info.alignment_log(lane),
                         email=",".join(manifest.email_addresses),
                         debug=debug,
@@ -276,6 +278,7 @@ def main(
                 continue
 
             processing_args = qsub_args(
+                project_name=config.project_name,
                 log_file=manifest.log_dir / "processing.$TASK_ID.log",
                 email=",".join(manifest.email_addresses),
                 debug=debug,
@@ -321,6 +324,7 @@ def main(
                 continue
 
             downsample_args = qsub_args(
+                project_name=config.project_name,
                 log_file=manifest.log_dir / "downsampling.$TASK_ID.log",
                 email=",".join(manifest.email_addresses),
                 debug=debug,

--- a/src/slideseq/scripts/alignment.sh
+++ b/src/slideseq/scripts/alignment.sh
@@ -7,7 +7,6 @@
 #$ -binding linear:8
 #$ -terse
 #$ -notify
-#$ -P macosko_lab
 #$ -R y
 #$ -j y
 #$ -m eas

--- a/src/slideseq/scripts/build_reference.sh
+++ b/src/slideseq/scripts/build_reference.sh
@@ -7,7 +7,6 @@
 #$ -binding linear:8
 #$ -terse
 #$ -notify
-#$ -P macosko_lab
 #$ -R y
 #$ -j y
 #$ -m beas

--- a/src/slideseq/scripts/demultiplex.sh
+++ b/src/slideseq/scripts/demultiplex.sh
@@ -7,7 +7,6 @@
 #$ -binding linear:8
 #$ -terse
 #$ -notify
-#$ -P macosko_lab
 #$ -R y
 #$ -j y
 #$ -m eas

--- a/src/slideseq/scripts/downsampling.sh
+++ b/src/slideseq/scripts/downsampling.sh
@@ -7,7 +7,6 @@
 #$ -binding linear:2
 #$ -terse
 #$ -notify
-#$ -P macosko_lab
 #$ -R y
 #$ -j y
 #$ -m eas

--- a/src/slideseq/scripts/processing.sh
+++ b/src/slideseq/scripts/processing.sh
@@ -7,7 +7,6 @@
 #$ -binding linear:4
 #$ -terse
 #$ -notify
-#$ -P macosko_lab
 #$ -R y
 #$ -j y
 #$ -m eas

--- a/src/slideseq/util/__init__.py
+++ b/src/slideseq/util/__init__.py
@@ -75,11 +75,16 @@ def rsync_to_google(path: Path, gs_path: Path):
 
 
 def qsub_args(
-    log_file: Path = None, email: str = None, debug: bool = False, **kwargs: Any
+    project_name: str = None,
+    log_file: Path = None,
+    email: str = None,
+    debug: bool = False,
+    **kwargs: Any,
 ) -> list[str]:
     """
     Returns command list starting with "qsub", adding configured options
 
+    :param project_name: name for the project to use with the -P option, if any
     :param log_file: path to log file for output
     :param email: Email addresses to include with the -M option. If None, emails will
                   be sent to the submitting user
@@ -92,6 +97,9 @@ def qsub_args(
 
     # standard options, including resources requests, are specified in the shell scripts
     arg_list = ["qsub"]
+
+    if project_name is not None:
+        arg_list.extend(["-P", project_name])
 
     if log_file is not None:
         arg_list.extend(["-o", f"{log_file.absolute().resolve()}"])


### PR DESCRIPTION
Had `-P macosko_lab` hard-coded in all the scripts, which meant that they failed if someone else tried to submit a job. This moves that to the config file which is more easily changed.